### PR TITLE
Dependency updates and Jasig->Apereo renames

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,6 @@
-Copyright 2010, JA-SIG, Inc.
-This project includes software developed by Jasig.
-http://www.jasig.org/
+Copyright 2010-2014, Apereo Foundation
+This project includes software developed by the Apereo Foundation.
+http://www.apereo.org/
 
 Licensed under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jasig.parent</groupId>
     <artifactId>jasig-parent</artifactId>
-    <version>35</version>
+    <version>40</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/src/main/resources/archetype-resources/NOTICE
+++ b/src/main/resources/archetype-resources/NOTICE
@@ -1,6 +1,6 @@
-Copyright 2010, JA-SIG, Inc.
-This project includes software developed by Jasig.
-http://www.jasig.org/
+Copyright 2010-2014, Apereo Foundation
+This project includes software developed by the Apereo Foundation.
+http://www.apereo.org/
 
 Licensed under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jasig.parent</groupId>
     <artifactId>jasig-parent</artifactId>
-    <version>35</version>
+    <version>40</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -21,14 +21,21 @@
   <properties>
     <portlet-api.version>2.0</portlet-api.version>
     <servlet-api.version>2.5</servlet-api.version>
-    <spring.version>3.1.4.RELEASE</spring.version>
+    <spring.version>4.2.2.RELEASE</spring.version>
     <jstl.version>1.2</jstl.version>
-    <logback.version>1.0.13</logback.version>
-    <junit.version>4.11</junit.version>
-    <resource-server.version>1.0.34</resource-server.version>
-    <slf4j.version>1.7.5</slf4j.version>
+    <logback.version>1.1.3</logback.version>
+    <junit.version>4.12</junit.version>
+    <resource-server.version>1.0.43</resource-server.version>
+    <slf4j.version>1.7.12</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
     <commons.version>1.1.3</commons.version>
+    <java.version>1.7</java.version>
+    <maven-surefire-plugin.version>2.16</maven-surefire-plugin.version>
+    <surefire-report-plugin.version>2.0-beta-1</surefire-report-plugin.version>
+    <cobertura-maven-plugin.version>2.4</cobertura-maven-plugin.version>
+    <findbugs-maven-plugin.version>2.3.1</findbugs-maven-plugin.version>
+    <maven-war-plugin.version>2.1</maven-war-plugin.version>
+    <uportal-maven-plugin.version>1.0.1</uportal-maven-plugin.version>
   </properties>
 
 
@@ -61,6 +68,21 @@
         <groupId>org.jasig.resourceserver</groupId>
         <artifactId>resource-server-utils</artifactId>
         <version>${resource-server.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-web</artifactId>
+        <version>${spring.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-beans</artifactId>
+        <version>${spring.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-context</artifactId>
+        <version>${spring.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -132,6 +154,18 @@
       <groupId>javax.portlet</groupId>
       <artifactId>portlet-api</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -216,7 +250,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.16</version>
+        <version>${maven-surefire-plugin.version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -230,7 +264,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>1.6</version>
+                  <version>${java.version}</version>
                 </requireJavaVersion>
               </rules>
             </configuration>
@@ -241,8 +275,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
         </configuration>
       </plugin>
       <plugin>
@@ -257,17 +291,17 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>surefire-report-maven-plugin</artifactId>
-        <version>2.0-beta-1</version>
+        <version>${surefire-report-plugin.version}</version>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.4</version>
+        <version>${cobertura-maven-plugin.version}</version>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
-        <version>2.3.1</version>
+        <version>${findbugs-maven-plugin.version}</version>
       </plugin>
     </plugins>
   </build>
@@ -292,7 +326,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-war-plugin</artifactId>
-            <version>2.1</version>
+            <version>${maven-war-plugin.version}</version>
             <configuration>
               <classifier>localdev</classifier>
               <warName>${project.artifactId}</warName>
@@ -302,7 +336,7 @@
           <plugin>
             <artifactId>org.jasig.portal.maven</artifactId>
             <groupId>uportal-maven-plugin</groupId>
-            <version>1.0.1</version>
+            <version>${uportal-maven-plugin.version}</version>
             <configuration>
               <contextName>${project.artifactId}</contextName>
               <artifactId>${project.artifactId}</artifactId>

--- a/src/main/resources/archetype-resources/src/main/java/mvc/IViewSelector.java
+++ b/src/main/resources/archetype-resources/src/main/java/mvc/IViewSelector.java
@@ -1,8 +1,8 @@
 /**
- * Licensed to Jasig under one or more contributor license
+ * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.
- * Jasig licenses this file to you under the Apache License,
+ * Apereo licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a
  * copy of the License at:

--- a/src/main/resources/archetype-resources/src/main/java/mvc/MinimizedStateHandlerInterceptor.java
+++ b/src/main/resources/archetype-resources/src/main/java/mvc/MinimizedStateHandlerInterceptor.java
@@ -1,8 +1,8 @@
 /**
- * Licensed to Jasig under one or more contributor license
+ * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.
- * Jasig licenses this file to you under the Apache License,
+ * Apereo licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a
  * copy of the License at:

--- a/src/main/resources/archetype-resources/src/main/java/mvc/ThemeNameViewSelectorImpl.java
+++ b/src/main/resources/archetype-resources/src/main/java/mvc/ThemeNameViewSelectorImpl.java
@@ -1,8 +1,8 @@
 /**
- * Licensed to Jasig under one or more contributor license
+ * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.
- * Jasig licenses this file to you under the Apache License,
+ * Apereo licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a
  * copy of the License at:

--- a/src/main/resources/archetype-resources/src/main/java/mvc/portlet/EditController.java
+++ b/src/main/resources/archetype-resources/src/main/java/mvc/portlet/EditController.java
@@ -1,8 +1,8 @@
 /**
- * Licensed to Jasig under one or more contributor license
+ * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.
- * Jasig licenses this file to you under the Apache License,
+ * Apereo licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a
  * copy of the License at:

--- a/src/main/resources/archetype-resources/src/main/java/mvc/portlet/HelpController.java
+++ b/src/main/resources/archetype-resources/src/main/java/mvc/portlet/HelpController.java
@@ -1,8 +1,8 @@
 /**
- * Licensed to Jasig under one or more contributor license
+ * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.
- * Jasig licenses this file to you under the Apache License,
+ * Apereo licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a
  * copy of the License at:

--- a/src/main/resources/archetype-resources/src/main/java/mvc/portlet/MainController.java
+++ b/src/main/resources/archetype-resources/src/main/java/mvc/portlet/MainController.java
@@ -1,8 +1,8 @@
 /**
- * Licensed to Jasig under one or more contributor license
+ * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.
- * Jasig licenses this file to you under the Apache License,
+ * Apereo licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a
  * copy of the License at:

--- a/src/main/resources/archetype-resources/src/main/resources/configuration.properties
+++ b/src/main/resources/archetype-resources/src/main/resources/configuration.properties
@@ -1,8 +1,8 @@
 #
-# Licensed to Jasig under one or more contributor license
+# Licensed to Apereo under one or more contributor license
 # agreements. See the NOTICE file distributed with this work
 # for additional information regarding copyright ownership.
-# Jasig licenses this file to you under the Apache License,
+# Apereo licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file
 # except in compliance with the License. You may obtain a
 # copy of the License at:

--- a/src/main/resources/archetype-resources/src/main/resources/logback.xml
+++ b/src/main/resources/archetype-resources/src/main/resources/logback.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Licensed to Jasig under one or more contributor license
+    Licensed to Apereo under one or more contributor license
     agreements. See the NOTICE file distributed with this work
     for additional information regarding copyright ownership.
-    Jasig licenses this file to you under the Apache License,
+    Apereo licenses this file to you under the Apache License,
     Version 2.0 (the "License"); you may not use this file
     except in compliance with the License. You may obtain a
     copy of the License at:

--- a/src/main/resources/archetype-resources/src/main/resources/messages.properties
+++ b/src/main/resources/archetype-resources/src/main/resources/messages.properties
@@ -1,8 +1,8 @@
 #
-# Licensed to Jasig under one or more contributor license
+# Licensed to Apereo under one or more contributor license
 # agreements. See the NOTICE file distributed with this work
 # for additional information regarding copyright ownership.
-# Jasig licenses this file to you under the Apache License,
+# Apereo licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file
 # except in compliance with the License. You may obtain a
 # copy of the License at:

--- a/src/main/resources/archetype-resources/src/main/webapp/META-INF/context.xml
+++ b/src/main/resources/archetype-resources/src/main/webapp/META-INF/context.xml
@@ -1,9 +1,9 @@
 <!--
 
-    Licensed to Jasig under one or more contributor license
+    Licensed to Apereo under one or more contributor license
     agreements. See the NOTICE file distributed with this work
     for additional information regarding copyright ownership.
-    Jasig licenses this file to you under the Apache License,
+    Apereo licenses this file to you under the Apache License,
     Version 2.0 (the "License"); you may not use this file
     except in compliance with the License. You may obtain a
     copy of the License at:

--- a/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/context/applicationContext.xml
+++ b/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/context/applicationContext.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Licensed to Jasig under one or more contributor license
+    Licensed to Apereo under one or more contributor license
     agreements. See the NOTICE file distributed with this work
     for additional information regarding copyright ownership.
-    Jasig licenses this file to you under the Apache License,
+    Apereo licenses this file to you under the Apache License,
     Version 2.0 (the "License"); you may not use this file
     except in compliance with the License. You may obtain a
     copy of the License at:

--- a/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/context/portlet/__artifactId__-portlet.xml
+++ b/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/context/portlet/__artifactId__-portlet.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-    Licensed to Jasig under one or more contributor license
+    Licensed to Apereo under one or more contributor license
     agreements. See the NOTICE file distributed with this work
     for additional information regarding copyright ownership.
-    Jasig licenses this file to you under the Apache License,
+    Apereo licenses this file to you under the Apache License,
     Version 2.0 (the "License"); you may not use this file
     except in compliance with the License. You may obtain a
     copy of the License at:

--- a/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/jsp/edit-jQM.jsp
+++ b/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/jsp/edit-jQM.jsp
@@ -1,9 +1,9 @@
 <%--
 
-    Licensed to Jasig under one or more contributor license
+    Licensed to Apereo under one or more contributor license
     agreements. See the NOTICE file distributed with this work
     for additional information regarding copyright ownership.
-    Jasig licenses this file to you under the Apache License,
+    Apereo licenses this file to you under the Apache License,
     Version 2.0 (the "License"); you may not use this file
     except in compliance with the License. You may obtain a
     copy of the License at:

--- a/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/jsp/edit.jsp
+++ b/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/jsp/edit.jsp
@@ -1,9 +1,9 @@
 <%--
 
-    Licensed to Jasig under one or more contributor license
+    Licensed to Apereo under one or more contributor license
     agreements. See the NOTICE file distributed with this work
     for additional information regarding copyright ownership.
-    Jasig licenses this file to you under the Apache License,
+    Apereo licenses this file to you under the Apache License,
     Version 2.0 (the "License"); you may not use this file
     except in compliance with the License. You may obtain a
     copy of the License at:

--- a/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/jsp/help-jQM.jsp
+++ b/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/jsp/help-jQM.jsp
@@ -1,9 +1,9 @@
 <%--
 
-    Licensed to Jasig under one or more contributor license
+    Licensed to Apereo under one or more contributor license
     agreements. See the NOTICE file distributed with this work
     for additional information regarding copyright ownership.
-    Jasig licenses this file to you under the Apache License,
+    Apereo licenses this file to you under the Apache License,
     Version 2.0 (the "License"); you may not use this file
     except in compliance with the License. You may obtain a
     copy of the License at:

--- a/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/jsp/help.jsp
+++ b/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/jsp/help.jsp
@@ -1,9 +1,9 @@
 <%--
 
-    Licensed to Jasig under one or more contributor license
+    Licensed to Apereo under one or more contributor license
     agreements. See the NOTICE file distributed with this work
     for additional information regarding copyright ownership.
-    Jasig licenses this file to you under the Apache License,
+    Apereo licenses this file to you under the Apache License,
     Version 2.0 (the "License"); you may not use this file
     except in compliance with the License. You may obtain a
     copy of the License at:

--- a/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/jsp/include.jsp
+++ b/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/jsp/include.jsp
@@ -1,9 +1,9 @@
 <%--
 
-    Licensed to Jasig under one or more contributor license
+    Licensed to Apereo under one or more contributor license
     agreements. See the NOTICE file distributed with this work
     for additional information regarding copyright ownership.
-    Jasig licenses this file to you under the Apache License,
+    Apereo licenses this file to you under the Apache License,
     Version 2.0 (the "License"); you may not use this file
     except in compliance with the License. You may obtain a
     copy of the License at:

--- a/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/jsp/main-jQM.jsp
+++ b/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/jsp/main-jQM.jsp
@@ -1,9 +1,9 @@
 <%--
 
-    Licensed to Jasig under one or more contributor license
+    Licensed to Apereo under one or more contributor license
     agreements. See the NOTICE file distributed with this work
     for additional information regarding copyright ownership.
-    Jasig licenses this file to you under the Apache License,
+    Apereo licenses this file to you under the Apache License,
     Version 2.0 (the "License"); you may not use this file
     except in compliance with the License. You may obtain a
     copy of the License at:

--- a/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -1,9 +1,9 @@
 <%--
 
-    Licensed to Jasig under one or more contributor license
+    Licensed to Apereo under one or more contributor license
     agreements. See the NOTICE file distributed with this work
     for additional information regarding copyright ownership.
-    Jasig licenses this file to you under the Apache License,
+    Apereo licenses this file to you under the Apache License,
     Version 2.0 (the "License"); you may not use this file
     except in compliance with the License. You may obtain a
     copy of the License at:

--- a/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/portlet.xml
+++ b/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/portlet.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Licensed to Jasig under one or more contributor license
+    Licensed to Apereo under one or more contributor license
     agreements. See the NOTICE file distributed with this work
     for additional information regarding copyright ownership.
-    Jasig licenses this file to you under the Apache License,
+    Apereo licenses this file to you under the Apache License,
     Version 2.0 (the "License"); you may not use this file
     except in compliance with the License. You may obtain a
     copy of the License at:

--- a/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Licensed to Jasig under one or more contributor license
@@ -21,10 +21,9 @@
 -->
 
 
-<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-    "http://java.sun.com/dtd/web-app_2_3.dtd">
-
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+	version="2.5">
 
   <display-name>uPortal Spring Portlet MVC UVIC ${artifactId} Wrapper</display-name>
 

--- a/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Licensed to Jasig under one or more contributor license
+    Licensed to Apereo under one or more contributor license
     agreements. See the NOTICE file distributed with this work
     for additional information regarding copyright ownership.
-    Jasig licenses this file to you under the Apache License,
+    Apereo licenses this file to you under the Apache License,
     Version 2.0 (the "License"); you may not use this file
     except in compliance with the License. You may obtain a
     copy of the License at:

--- a/src/main/resources/archetype-resources/src/test/java/AppTest.java
+++ b/src/main/resources/archetype-resources/src/test/java/AppTest.java
@@ -1,8 +1,8 @@
 /**
- * Licensed to Jasig under one or more contributor license
+ * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.
- * Jasig licenses this file to you under the Apache License,
+ * Apereo licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a
  * copy of the License at:

--- a/src/main/resources/archetype-resources/src/test/resources/logback-test.xml
+++ b/src/main/resources/archetype-resources/src/test/resources/logback-test.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Licensed to Jasig under one or more contributor license
+    Licensed to Apereo under one or more contributor license
     agreements. See the NOTICE file distributed with this work
     for additional information regarding copyright ownership.
-    Jasig licenses this file to you under the Apache License,
+    Apereo licenses this file to you under the Apache License,
     Version 2.0 (the "License"); you may not use this file
     except in compliance with the License. You may obtain a
     copy of the License at:


### PR DESCRIPTION
@jameswennmacher I updated the dependencies to more recent versions. I also changed the license headers in the source files to say Apereo instead of Jasig.